### PR TITLE
Pass machine name to with_target_vms helper

### DIFF
--- a/lib/vagrant-fsnotify/command-fsnotify.rb
+++ b/lib/vagrant-fsnotify/command-fsnotify.rb
@@ -19,7 +19,7 @@ module VagrantPlugins::Fsnotify
       ignores = []
       @changes = {}
 
-      with_target_vms do |machine|
+      with_target_vms(argv) do |machine|
         if !machine.communicate.ready?
           machine.ui.error("Machine not ready, is it up?")
           return 1


### PR DESCRIPTION
Hi @adrienkohlbecker,

I've been using your plugin for the last couple of weeks with great success. The one place it doesn't work is when I use it with multi-machines like so:

  `vagrant fsnotify SOME_MACHINE` 

This will actually try to run fsnotify on all machines listed in the Vagrantfile.

I use a multi-machine setup with my Vagrant machines and found that the `with_target_vms` [helper takes a names argument](https://github.com/mitchellh/vagrant/blob/efd1d5e11bfc5a72c7a1d1eae294b4751d841544/lib/vagrant/plugin/v1/command.rb#L66) which allows you to target the commands to a list of machines.
 
Thanks for a great little plugin!