### PR TITLE
Fix dependency conflict

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ group :development do
 end
 
 group :plugins do
-  gemspec
+  gem "vagrant-fsnotify", path: "."
 end

--- a/vagrant-fsnotify.gemspec
+++ b/vagrant-fsnotify.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "listen", "2.8.0"
+  spec.add_dependency "vagrant", "~> 1.5"
 
-  spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
When I started the work on https://github.com/adrienkohlbecker/vagrant-fsnotify/issues/2, I stumbled upon the following issue:

Multiple incompatible versions of gems were declared on the `Gemfile`
and `.gemspec`, causing `bundle install` to fail. This didn't cause
issues for regular users, but was a problem for `vagrant-fsnotify`
developers which would get error messages like the following when
running `bundle install`:

```
Bundler could not find compatible versions for gem "bundler":
In Gemfile:
     bundler (~> 1.9) ruby

Current Bundler version:
                  bundler (1.6.9)

This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?
```

In particular the conflicts were the following:

1. `bundler` version on the `.gemspec` was `~> 1.9`, but the Vagrant
    version specified on the `Gemfile` is `v1.6.3`, which required
    `bundler` `< 1.7.0`[1].

2. `listen` version on the `.gemspec` was `2.8.0`, but the Vagrant
    version specified on the `Gemfile` is `v1.6.3`, which required
    `listen` `~> 2.7.1`[2].

The solution was to change both the `Gemfile` and the `.gemspec`.

On the `Gemfile`, follow Vagrant recommendation[3]. Instead of relying
on declaring `gemspec` on the `plugins` group, specifically add the gem.

This has the side effect of not installing the development dependencies
on the `Gemfile`, but that's not an issue since there are no non-trivial
dependencies there yet.

Strictly speaking, this change wasn't necessary to fix the issue, but
it's better for follow the recommendation by Vagrant developers unless
there's a good reason to deviate.

On the `.gemspec`, don't specify versions of the development
dependencies. Those are dependencies that change very infrequently and
there's nothing on `vagrant-fsnotify` that should require an specific
version.

Finally, instead of explicitly depending on `listen`, depend on
`vagrant`, which in turn depends on `listen`. In fact, as a Vagrant
plugin, `vagrant-fsnotify` is relying on the Listen gem installed by the
Vagrant installer, so this makes sense.

Depending on Vagrant has the advantage to enforce the required version
on the installation, instead of waiting until the first execution to
fail on the assertion present on the `vagrant-fsnotify` loader[4].

The check is left there, though, to avoid issues for people using the
plugin with some weird setup.

[1]: https://github.com/mitchellh/vagrant/blob/v1.6.3/vagrant.gemspec#L18
[2]: https://github.com/mitchellh/vagrant/blob/v1.6.3/vagrant.gemspec#L22
[3]: https://docs.vagrantup.com/v2/plugins/development-basics.html
[4]: https://github.com/adrienkohlbecker/vagrant-fsnotify/blob/11de27584f82dbd9579776bc4960ba672ab7f530/lib/vagrant-fsnotify/plugin.rb#L7-L9