### PR TITLE
Fix Celluloid dependency

### DIFF
--- a/vagrant-fsnotify.gemspec
+++ b/vagrant-fsnotify.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "vagrant", "~> 1.5"
-
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Unfortunately the work done in
https://github.com/adrienkohlbecker/vagrant-fsnotify/pull/5 has one
showstopping mistake!

Depending on Vagrant causes the Vagrant dependencies to be installed
along with the plugins. This makes sense, after all Vagrant is just
another gem.

Among the gems that are installed, comes Celluloid. Unfortunately,
having it installed along the Vagrant plugin causes the following
exception to be raised when starting vagrant-fsnotify:

    /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/calls.rb:48:in `check': wrong number of arguments (2 for 1) (ArgumentError)
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/calls.rb:26:in `dispatch'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/call/sync.rb:16:in `dispatch'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/cell.rb:50:in `block in dispatch'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/cell.rb:76:in `block in task'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/actor.rb:363:in `block in task'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/task.rb:57:in `block in initialize'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/task/fibered.rb:14:in `block in create'
    	from (celluloid):0:in `remote procedure call'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/call/sync.rb:45:in `value'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-0.17.0/lib/celluloid/proxy/sync.rb:40:in `method_missing'
    	from /Users/leafac/.vagrant.d/gems/gems/listen-2.8.6/lib/listen/listener.rb:206:in `_init_actors'
    	from /Users/leafac/.vagrant.d/gems/gems/listen-2.8.6/lib/listen/listener.rb:87:in `block in <class:Listener>'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-fsm-0.20.0/lib/celluloid/fsm.rb:176:in `instance_eval'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-fsm-0.20.0/lib/celluloid/fsm.rb:176:in `call'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-fsm-0.20.0/lib/celluloid/fsm.rb:129:in `transition_with_callbacks!'
    	from /Users/leafac/.vagrant.d/gems/gems/celluloid-fsm-0.20.0/lib/celluloid/fsm.rb:97:in `transition'
    	from /Users/leafac/.vagrant.d/gems/gems/listen-2.8.6/lib/listen/listener.rb:100:in `start'
    	from /Users/leafac/.vagrant.d/gems/gems/vagrant-fsnotify-0.1.1/lib/vagrant-fsnotify/command-fsnotify.rb:132:in `block in execute'
    	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/util/busy.rb:19:in `busy'
    	from /Users/leafac/.vagrant.d/gems/gems/vagrant-fsnotify-0.1.1/lib/vagrant-fsnotify/command-fsnotify.rb:131:in `execute'
    	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/cli.rb:42:in `execute'
    	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:301:in `cli'
    	from /opt/vagrant/bin/../embedded/gems/gems/vagrant-1.7.2/bin/vagrant:174:in `<main>'

vagrant-fsnotify completely breaks!

The solution is to remove Vagrant from the list of dependencies on the
`.gemspec` altogether. The plugin is installed with `vagrant plugin
install vagrant-fsnotify`, so Vagrant is already present on the system
and doesn't need to be specified as a dependency.

This is what a few other plugins I use do:

- https://github.com/leighmcculloch/vagrant-docker-compose/blob/f07190fcad678048b7bc2dc41cc228e9b4712256/vagrant-docker-compose.gemspec
- https://github.com/p0deje/vagrant-exec/blob/ede88ef8ede1a3d92f60ea54e426b8396d589090/vagrant-exec.gemspec

Note that there's no dependency on Vagrant there.

To make matters worse, if someone installed vagrant-fsnotify 1.0.0, the
installation of celluloid stays there even after `vagrant plugin
uninstall vagrant-fsnotify`. The solution for me was to:

    rm -rf ~/.vagrant.d/

But be warned that this is heavy-handed, it uninstalls all Vagrant
plugins and may have other consequences I'm unaware of. I have a script
that installs my Vagrant plugins back, so it was easy for me to restore
a working state.

Accepting this PR requires only a bugfix bump on the version.