### PR TITLE
Update to latest listen

### DIFF
--- a/lib/vagrant-fsnotify/command-fsnotify.rb
+++ b/lib/vagrant-fsnotify/command-fsnotify.rb
@@ -131,7 +131,7 @@ MESSAGE
       Vagrant::Util::Busy.busy(callback) do
         listener.start
         queue.pop
-        listener.stop if listener.listen?
+        listener.stop if listener.state != :stopped
       end
 
       return 0

--- a/lib/vagrant-fsnotify/plugin.rb
+++ b/lib/vagrant-fsnotify/plugin.rb
@@ -4,8 +4,12 @@ rescue LoadError
   raise "The vagrant-fsnotify plugin must be run within Vagrant."
 end
 
-if Vagrant::VERSION < "1.5"
-  raise "The vagrant-fsnotify plugin is only compatible with Vagrant 1.5+"
+if Vagrant::VERSION < "1.7.3"
+  raise <<-ERROR
+The vagrant-fsnotify plugin is only compatible with Vagrant 1.7.3+. If you can't
+upgrade, consider installing an old version of vagrant-fsnotify with:
+  $ vagrant plugin install vagrant-fsnotify --plugin-version 0.0.6.
+ERROR
 end
 
 module VagrantPlugins::Fsnotify


### PR DESCRIPTION
Hi, @adrienkohlbecker.

It turns out I found out what was causing the issue https://github.com/adrienkohlbecker/vagrant-fsnotify/issues/9.

It had nothing to do with `vagrant-fsnotify` itself. In fact, not even yanking the `0.1.0` series out of RubyGems fixed the problem.

The problem was [Celluloid 0.17.0](https://rubygems.org/gems/celluloid/versions/0.17.0) was released 2015-07-04, the day we were working on `vagrant-fsnotify`! Unfortunate coincidence that caused a lot of misunderstanding.

Vagrant 1.7.3 fixes the issue (https://github.com/mitchellh/vagrant/commit/d5458247c7490f0eff79d3e39679a22c5d67ae81) by updating Listen (which in turn works with the latest Celluloid).

This commit applies the same change as Vagrant itself in the rsync-auto feature which is very similar to `vagrant-fsnotify`.

Once you merge this, please, feel free to deploy a `0.1.2` version. Contrary to what I suggested earlier, I don't think a beta release is necessary. I already tested from end to end with my `vagrant-fsnotify-tmp` fake gem.

Thanks so much for you patience with my back and forth and thanks for handling the release process for this so useful gem.

Best.

Fixes https://github.com/adrienkohlbecker/vagrant-fsnotify/issues/9.

Reference: https://github.com/mitchellh/vagrant/commit/d5458247c7490f0eff79d3e39679a22c5d67ae81