### PR TITLE
Run fsnotify as a daemon on 'vagrant up'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem "daemons"
+
 group :development do
   gem "vagrant", git: "https://github.com/mitchellh/vagrant.git", ref: 'v1.7.3'
 end

--- a/lib/vagrant-fsnotify/action/halt.rb
+++ b/lib/vagrant-fsnotify/action/halt.rb
@@ -1,6 +1,6 @@
 require 'daemons'
 
-module VagrantPlugins::Uptime::Action
+module VagrantPlugins::Fsnotify::Action
   class Halt
     def initialize(app, env)
       @app = app

--- a/lib/vagrant-fsnotify/action/halt.rb
+++ b/lib/vagrant-fsnotify/action/halt.rb
@@ -1,4 +1,5 @@
 require 'daemons'
+require 'vagrant-fsnotify/daemon'
 
 module VagrantPlugins::Fsnotify::Action
   class Halt
@@ -7,14 +8,9 @@ module VagrantPlugins::Fsnotify::Action
     end
 
     def call(env)
+      VagrantPlugins::Fsnotify::Daemon.new(env).stop
+      env[:ui].info "Stopped fsnotify daemon."
       @app.call(env)
-      halt env
     end
-
-    protected
-      def halt(env)
-        task = VagrantPlugins::Fsnotify.task
-        task.stop
-      end
   end
 end

--- a/lib/vagrant-fsnotify/action/halt.rb
+++ b/lib/vagrant-fsnotify/action/halt.rb
@@ -1,0 +1,20 @@
+require 'daemons'
+
+module VagrantPlugins::Uptime::Action
+  class Halt
+    def initialize(app, env)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+      halt env
+    end
+
+    protected
+      def halt(env)
+        task = VagrantPlugins::Fsnotify.task
+        task.stop
+      end
+  end
+end

--- a/lib/vagrant-fsnotify/action/up.rb
+++ b/lib/vagrant-fsnotify/action/up.rb
@@ -1,0 +1,23 @@
+require 'daemons'
+
+module VagrantPlugins::Fsnotify::Action
+  class Up
+    def initialize(app, env)
+      @app = app
+    end
+
+    def call(env)
+      up
+      @app.call(env)
+    end
+
+    protected
+      def up
+        task = Daemons.call do
+          VagrantPlugins::Fsnotify::Command.execute
+        end
+        task.start
+        VagrantPlugins::Fsnotify.task = task
+      end
+  end
+end

--- a/lib/vagrant-fsnotify/action/up.rb
+++ b/lib/vagrant-fsnotify/action/up.rb
@@ -1,4 +1,5 @@
 require 'daemons'
+require 'vagrant-fsnotify/daemon'
 
 module VagrantPlugins::Fsnotify::Action
   class Up
@@ -7,17 +8,9 @@ module VagrantPlugins::Fsnotify::Action
     end
 
     def call(env)
-      up
+      VagrantPlugins::Fsnotify::Daemon.new(env).start
+      env[:ui].info "Started fsnotify daemon."
       @app.call(env)
     end
-
-    protected
-      def up
-        task = Daemons.call do
-          VagrantPlugins::Fsnotify::Command.execute
-        end
-        task.start
-        VagrantPlugins::Fsnotify.task = task
-      end
   end
 end

--- a/lib/vagrant-fsnotify/daemon.rb
+++ b/lib/vagrant-fsnotify/daemon.rb
@@ -1,0 +1,41 @@
+require 'daemons'
+
+module VagrantPlugins::Fsnotify
+  class Daemon
+    attr_accessor :machine
+    attr_accessor :tmp_path
+
+    def initialize(env)
+      self.machine = env[:machine]
+      self.tmp_path = File.join(self.machine.env.tmp_path, "fsnotify")
+      FileUtils.mkdir_p(self.tmp_path)
+    end
+
+    def start
+      run_options = {:ARGV => ["start"]}.merge(runopts)
+      run(run_options)
+    end
+
+    def stop
+      run_options = {:ARGV => ["stop"]}.merge(runopts)
+      run(run_options)
+    end
+
+    protected
+
+    def run(run_options)
+      Daemons.run_proc("vagrant-fsnotify", run_options) do
+        self.machine.env.cli("fsnotify")
+      end
+    end
+
+    def runopts
+      {
+        :dir_mode   => :normal,
+        :dir        => tmp_path,
+        :log_output => true,
+        :log_dir    => tmp_path
+      }
+    end
+  end
+end

--- a/lib/vagrant-fsnotify/plugin.rb
+++ b/lib/vagrant-fsnotify/plugin.rb
@@ -22,6 +22,16 @@ module VagrantPlugins::Fsnotify
       Command
     end
 
+    action_hook("up", 'machine_action_up') do |hook|
+      require_relative "action/up"
+      hook.append(Action::Up)
+    end
+
+    action_hook("halt", 'machine_action_halt') do |hook|
+      require_relative "action/halt"
+      hook.prepend(Action::Halt)
+    end
+
   end
 
 end

--- a/lib/vagrant-fsnotify/version.rb
+++ b/lib/vagrant-fsnotify/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Fsnotify
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/vagrant-fsnotify.gemspec
+++ b/vagrant-fsnotify.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "daemons"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This PR extends on the work by @toobulkeh in PR #14.

This change makes fsnotify run as a daemon, eliminating the need to run `vagrant fsnotify` manually. This allows users to gain the benefits of the plugin without changing how they interact with Vagrant.

The approach is based on the code used by [BerlinVagrant/vagrant-dns](https://github.com/BerlinVagrant/vagrant-dns) to start a persistent daemon from a Vagrant event.

### Features:
- When a Vagrant VM is started (`vagrant up`), the fsnotify command is automatically run in a daemon.
- When the machine is halted (`vagrant halt`), the daemon is stopped.

### Limitations:
- The daemon will be started for all Vagrantfiles, regardless of whether they use fsnotify. If the Vagrantfile doesn't use the plugin, an error will be printed to the log and the daemon will exit.
- The daemon is run using as a call to the Vagrant CLI ([details](http://www.rubydoc.info/github/mitchellh/vagrant/Vagrant/Environment#cli-instance_method). In the future, the heavy lifting of `vagrant-fsnotify` should be moved out of the CLI command allowing it to be called by the daemon directly.

Tested with Vagrant version 1.9.1. Looking at the [Vagrant changelog](https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md) I don't see any reason why this won't work down to version 1.7.3.