### PR TITLE
Add parameter to allow selection of touch flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.3.2 - 2021-06-18
+==================
+- Add parameter to allow selection of touch flags
+
 0.3.1 - 2019-04-11
 ==================
 - Update mtime as well as atime to trigger file events on the guest (#28)

--- a/README.md
+++ b/README.md
@@ -158,6 +158,26 @@ folder, add the following to the `Vagrantfile`:
 config.vm.synced_folder ".", "/vagrant", fsnotify: [:added]
 ```
 
+### Set touch flags
+
+By default, the touch command on the VM will be run with modification flag and access flag, setting
+both modification and access attributes of the file. If only either flag should be used the `:touch`
+param can be set per machine config in the `Vagrantfile`. The param supports an array with either or both 
+`:modification` and `:access` values. 
+
+As example, to only set the access attribute of files when they have changed on the host system set the following
+in the `Vagrantfile`:
+
+```ruby
+config.fsnotify.touch = [:access]
+```
+or for instances and providers
+```ruby
+config.vm.define "vm" do |instance|
+    instance.fsnotify.touch = [:access]
+end
+```
+
 Development
 -------------
 

--- a/lib/vagrant-fsnotify/command-fsnotify.rb
+++ b/lib/vagrant-fsnotify/command-fsnotify.rb
@@ -199,7 +199,8 @@ MESSAGE
       end
 
       tosync.each do |machine, files|
-        machine.communicate.execute("touch -am '#{files.join("' '")}'")
+        touch_flags = get_touch_flags(machine.config.fsnotify.touch)
+        machine.communicate.execute("touch -#{touch_flags} '#{files.join("' '")}'")
         remove_from_this_machine = files & todelete
         unless remove_from_this_machine.empty?
           machine.communicate.execute("rm -rf '#{remove_from_this_machine.join("' '")}'")
@@ -223,5 +224,14 @@ MESSAGE
 
     end
 
+    def get_touch_flags(touch)
+      if touch.include? :modification and not touch.include? :access
+        return "m"
+      elsif not touch.include? :modification and touch.include? :access
+        return "a"
+      else
+        return "am"
+      end
+    end
   end
 end

--- a/lib/vagrant-fsnotify/config-fsnotify.rb
+++ b/lib/vagrant-fsnotify/config-fsnotify.rb
@@ -14,19 +14,16 @@ end
 
 module VagrantPlugins::Fsnotify
 
-  class Plugin < Vagrant.plugin("2")
-    name "vagrant-fsnotify"
+  class Config < Vagrant.plugin("2", :config)
+    attr_accessor :touch
 
-    command "fsnotify" do
-      require_relative "command-fsnotify"
-      Command
+    def initialize
+      @touch = UNSET_VALUE
     end
 
-    config "fsnotify" do
-      require_relative "config-fsnotify"
-      Config
+    def finalize!
+      @touch = [:modification, :access] if @touch == UNSET_VALUE
     end
-
   end
 
 end

--- a/lib/vagrant-fsnotify/version.rb
+++ b/lib/vagrant-fsnotify/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module Fsnotify
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end


### PR DESCRIPTION
Adding a Vagrantfile param to select touch flags. I have loopback issues ("File Cache Conflict﻿") with JetBrains when files that are currently open have external access-events. Webpack listens only for modification-events, so only using modification when touching is an easy fix. (```config.fsnotify.touch = [:modification]```)

 If not set, the default is the same as in previous version, so no breaking changes.

This is an old problem (at least for me) happening with vagrant + vagrant-sshfs + vagrant-libvirt + vagrant-fsnotify.